### PR TITLE
Replace virtual noise diode sensor with real one

### DIFF
--- a/kattelmod/rts_session.py
+++ b/kattelmod/rts_session.py
@@ -719,9 +719,6 @@ class CaptureSession(CaptureSessionBase):
         # Switch noise diode on on all antennas
         on_time = time.time()
         ants.req.dig_noise_source('now', 1)
-        # Fake the noise diode sensor for now via cam2spead
-        for ant in ants:
-            data.req.set_nd_sensor(product, ant.name, on_time, 1)
         # If using Data simulator, fire the simulated noise diode for desired period to toggle power levels in output
         if hasattr(data.req, 'data_fire_nd'):
             data.req.data_fire_nd(np.ceil(float(on) / dump_period))
@@ -732,9 +729,6 @@ class CaptureSession(CaptureSessionBase):
         session.last_nd_firing = off_time
         # Switch noise diode off on all antennas
         ants.req.dig_noise_source('now', 0)
-        # Fake the noise diode sensor for now via cam2spead
-        for ant in ants:
-            data.req.set_nd_sensor(product, ant.name, off_time, 0)
         time.sleep(off)
 
         user_logger.info('noise diode fired')


### PR DESCRIPTION
Instead of calling cam2spead to set the virtual nd sensor (via the data
proxy), rather use the newly provided digitiser sensor (dig.noise-diode).
The new sensor is not much better than the virtual one, but requires
less work from SP + CAM.

@brickZA, more of the same.
