### PR TITLE
Fix up hostname for sdp-ingest4

### DIFF
--- a/kattelmod/systems/mkat/sim_16ant.cfg
+++ b/kattelmod/systems/mkat/sim_16ant.cfg
@@ -17,4 +17,4 @@ m06+ =   23
 
 [sdp]
 master_controller = 'sdp-ingest5.kat.ac.za:5001'
-cbf_spead = '192.168.6.230:7148'
+cbf_spead = 'sdp-ingest4.kat.ac.za:7148'

--- a/kattelmod/systems/mkat/sim_2ant.cfg
+++ b/kattelmod/systems/mkat/sim_2ant.cfg
@@ -11,4 +11,4 @@ names = m062,m063
 
 [sdp]
 master_controller = 'sdp-ingest5.kat.ac.za:5001'
-cbf_spead = '192.168.6.229:7148'
+cbf_spead = 'sdp-ingest4.kat.ac.za:7148'

--- a/kattelmod/systems/mkat/sim_60ant.cfg
+++ b/kattelmod/systems/mkat/sim_60ant.cfg
@@ -17,4 +17,4 @@ m06+ = 0123
 
 [sdp]
 master_controller = 'sdp-ingest5.kat.ac.za:5001'
-cbf_spead = '192.168.6.229:7148'
+cbf_spead = 'sdp-ingest4.kat.ac.za:7148'


### PR DESCRIPTION
Now uses a hostname, since DNS should now work for this host.
