### PR TITLE
Add simulated systems for 32 antennas, for AR2 tests

### DIFF
--- a/kattelmod/systems/mkat/sim_32ant.cfg
+++ b/kattelmod/systems/mkat/sim_32ant.cfg
@@ -1,0 +1,21 @@
+[Telescope mkat]
+ants* = fake.AntennaPositioner
+sub = fake.Subarray
+env = fake.Environment
+cbf = sdp.CorrelatorBeamformer
+sdp = sdp.ScienceDataProcessor
+obs = fake.Observation
+
+[ants]
+m00+ = 0123 5678
+m01+ = 012 45 78
+m02+ = 012 45
+m03+ =  1  4 6
+m04+ =   2      9
+m05+ =        789
+m06+ = 0123
+
+[sdp]
+master_controller = 'sdp-ingest5.kat.ac.za:5001'
+input_streams = {"cbf.baseline_correlation_products": {"i0.baseline-correlation-products": "spead://225.100.254.1+31:7148"},
+                 "cbf.antenna_channelised_voltage": {"i0.antenna-channelised-voltage": "spead://225.100.254.33+31:7148"}}

--- a/kattelmod/systems/mkat/sim_32ant_32k.cfg
+++ b/kattelmod/systems/mkat/sim_32ant_32k.cfg
@@ -1,0 +1,25 @@
+[Telescope mkat]
+ants* = fake.AntennaPositioner
+sub = fake.Subarray
+env = fake.Environment
+cbf = sdp.CorrelatorBeamformer
+sdp = sdp.ScienceDataProcessor
+obs = fake.Observation
+
+[ants]
+m00+ = 0123 5678
+m01+ = 012 45 78
+m02+ = 012 45
+m03+ =  1  4 6
+m04+ =   2      9
+m05+ =        789
+m06+ = 0123
+
+[sub]
+product = 'c856M32k'
+dump_rate = 0.5
+
+[sdp]
+master_controller = 'sdp-ingest5.kat.ac.za:5001'
+input_streams = {"cbf.baseline_correlation_products": {"i0.baseline-correlation-products": "spead://225.100.254.1+31:7148"},
+                 "cbf.antenna_channelised_voltage": {"i0.antenna-channelised-voltage": "spead://225.100.254.33+31:7148"}}


### PR DESCRIPTION
The antenna list was taken from a real 32-ant single-pol observation. Apart from the antenna list change, the streams have twice as many multicast IP addresses as before (since that's how CBF works).