### PR TITLE
Use IP addresses from 239.* range for simulated CBF streams

### DIFF
--- a/kattelmod/systems/mkat/sim_16ant.cfg
+++ b/kattelmod/systems/mkat/sim_16ant.cfg
@@ -17,5 +17,5 @@ m06+ =   23
 
 [sdp]
 master_controller = 'sdp-ingest5.kat.ac.za:5001'
-input_streams = {"cbf.baseline_correlation_products": {"i0.baseline-correlation-products": "spead://225.100.254.1+15:7148"},
-                 "cbf.antenna_channelised_voltage": {"i0.antenna-channelised-voltage": "spead://225.100.254.17+15:7148"}}
+input_streams = {"cbf.baseline_correlation_products": {"i0.baseline-correlation-products": "spead://239.102.1.0+15:7148"},
+                 "cbf.antenna_channelised_voltage": {"i0.antenna-channelised-voltage": "spead://239.102.1.16+15:7148"}}

--- a/kattelmod/systems/mkat/sim_2ant.cfg
+++ b/kattelmod/systems/mkat/sim_2ant.cfg
@@ -11,5 +11,5 @@ names = m062,m063
 
 [sdp]
 master_controller = 'sdp-ingest5.kat.ac.za:5001'
-input_streams = {"cbf.baseline_correlation_products": {"i0.baseline-correlation-products": "spead://225.100.254.1+15:7148"},
-                 "cbf.antenna_channelised_voltage": {"i0.antenna-channelised-voltage": "spead://225.100.254.17+15:7148"}}
+input_streams = {"cbf.baseline_correlation_products": {"i0.baseline-correlation-products": "spead://239.102.1.0+15:7148"},
+                 "cbf.antenna_channelised_voltage": {"i0.antenna-channelised-voltage": "spead://239.102.1.16+15:7148"}}

--- a/kattelmod/systems/mkat/sim_32ant.cfg
+++ b/kattelmod/systems/mkat/sim_32ant.cfg
@@ -17,5 +17,5 @@ m06+ = 0123
 
 [sdp]
 master_controller = 'sdp-ingest5.kat.ac.za:5001'
-input_streams = {"cbf.baseline_correlation_products": {"i0.baseline-correlation-products": "spead://225.100.254.1+31:7148"},
-                 "cbf.antenna_channelised_voltage": {"i0.antenna-channelised-voltage": "spead://225.100.254.33+31:7148"}}
+input_streams = {"cbf.baseline_correlation_products": {"i0.baseline-correlation-products": "spead://239.102.1.0+31:7148"},
+                 "cbf.antenna_channelised_voltage": {"i0.antenna-channelised-voltage": "spead://239.102.1.32+31:7148"}}

--- a/kattelmod/systems/mkat/sim_32ant_32k.cfg
+++ b/kattelmod/systems/mkat/sim_32ant_32k.cfg
@@ -21,5 +21,5 @@ dump_rate = 0.5
 
 [sdp]
 master_controller = 'sdp-ingest5.kat.ac.za:5001'
-input_streams = {"cbf.baseline_correlation_products": {"i0.baseline-correlation-products": "spead://225.100.254.1+31:7148"},
-                 "cbf.antenna_channelised_voltage": {"i0.antenna-channelised-voltage": "spead://225.100.254.33+31:7148"}}
+input_streams = {"cbf.baseline_correlation_products": {"i0.baseline-correlation-products": "spead://239.102.1.0+31:7148"},
+                 "cbf.antenna_channelised_voltage": {"i0.antenna-channelised-voltage": "spead://239.102.1.32+31:7148"}}

--- a/kattelmod/systems/mkat/sim_60ant.cfg
+++ b/kattelmod/systems/mkat/sim_60ant.cfg
@@ -17,5 +17,5 @@ m06+ = 0123
 
 [sdp]
 master_controller = 'sdp-ingest5.kat.ac.za:5001'
-input_streams = {"cbf.baseline_correlation_products": {"i0.baseline-correlation-products": "spead://225.100.254.1+15:7148"},
-                 "cbf.antenna_channelised_voltage": {"i0.antenna-channelised-voltage": "spead://225.100.254.17+15:7148"}}
+input_streams = {"cbf.baseline_correlation_products": {"i0.baseline-correlation-products": "spead://239.102.1.0+63:7148"},
+                 "cbf.antenna_channelised_voltage": {"i0.antenna-channelised-voltage": "spead://239.102.1.64+63:7148"}}


### PR DESCRIPTION
This assists with routing the streams correctly, since we generally set
239.* to route through the interfaces to the CBF 40Gb network. The
239.102.* range has been reserved for us in the MeerKAT IP list.