### PR TITLE
Update to master controller API version 2.0

### DIFF
--- a/kattelmod/systems/mkat/generate_sim_config.py
+++ b/kattelmod/systems/mkat/generate_sim_config.py
@@ -64,7 +64,7 @@ def generate(argv):
     n_accs = int(round(0.5 * bandwidth / args.channels / 256)) * 256
     cbf_int_time = n_accs * args.channels / bandwidth
     config = {
-        "version": "1.1",
+        "version": "2.0",
         "inputs": {
             "i0_antenna_channelised_voltage": {
                 "type": "cbf.antenna_channelised_voltage",
@@ -97,18 +97,26 @@ def generate(argv):
         },
         "outputs": {
             "sdp_l0": {
-                "type": "sdp.l0",
+                "type": "sdp.vis",
                 "src_streams": ["i0_baseline_correlation_products"],
-                "continuum_factor": 1
+                "continuum_factor": 1,
+                "archive": True
             },
             "sdp_l0_continuum": {
-                "type": "sdp.l0",
+                "type": "sdp.vis",
                 "src_streams": ["i0_baseline_correlation_products"],
-                "continuum_factor": 16
+                "continuum_factor": 16,
+                "archive": False
             },
             "cal": {
                 "type": "sdp.cal",
                 "src_streams": ["sdp_l0"]
+            },
+            "sdp_l1_flags": {
+                "type": "sdp.flags",
+                "src_streams": ["sdp_l0"],
+                "calibration": ["cal"],
+                "archive": True
             }
         },
         "config": {}

--- a/kattelmod/systems/mkat/sdp.py
+++ b/kattelmod/systems/mkat/sdp.py
@@ -65,7 +65,7 @@ class ScienceDataProcessor(KATCPComponent):
                     simulate['antennas'] = [receptor.description for receptor in receptors]
         # Insert the dump rate
         for output in config['outputs'].values():
-            if output['type'] == 'sdp.l0':
+            if output['type'] in ['sdp.l0', 'sdp.vis']:
                 output['output_int_time'] = 1.0 / sub.dump_rate
         msg = self._client.req.product_configure(subarray_product, json.dumps(config),
                                                  timeout=300)

--- a/kattelmod/systems/mkat/sim_16ant.cfg
+++ b/kattelmod/systems/mkat/sim_16ant.cfg
@@ -58,19 +58,31 @@ config = {
                 "type": "sdp.cal"
             }, 
             "sdp_l0": {
+                "archive": true, 
                 "continuum_factor": 1, 
                 "src_streams": [
                     "i0_baseline_correlation_products"
                 ], 
-                "type": "sdp.l0"
+                "type": "sdp.vis"
             }, 
             "sdp_l0_continuum": {
+                "archive": false, 
                 "continuum_factor": 16, 
                 "src_streams": [
                     "i0_baseline_correlation_products"
                 ], 
-                "type": "sdp.l0"
+                "type": "sdp.vis"
+            }, 
+            "sdp_l1_flags": {
+                "archive": true, 
+                "calibration": [
+                    "cal"
+                ], 
+                "src_streams": [
+                    "sdp_l0"
+                ], 
+                "type": "sdp.flags"
             }
         }, 
-        "version": "1.1"
+        "version": "2.0"
     }

--- a/kattelmod/systems/mkat/sim_2ant.cfg
+++ b/kattelmod/systems/mkat/sim_2ant.cfg
@@ -58,19 +58,31 @@ config = {
                 "type": "sdp.cal"
             }, 
             "sdp_l0": {
+                "archive": true, 
                 "continuum_factor": 1, 
                 "src_streams": [
                     "i0_baseline_correlation_products"
                 ], 
-                "type": "sdp.l0"
+                "type": "sdp.vis"
             }, 
             "sdp_l0_continuum": {
+                "archive": false, 
                 "continuum_factor": 16, 
                 "src_streams": [
                     "i0_baseline_correlation_products"
                 ], 
-                "type": "sdp.l0"
+                "type": "sdp.vis"
+            }, 
+            "sdp_l1_flags": {
+                "archive": true, 
+                "calibration": [
+                    "cal"
+                ], 
+                "src_streams": [
+                    "sdp_l0"
+                ], 
+                "type": "sdp.flags"
             }
         }, 
-        "version": "1.1"
+        "version": "2.0"
     }

--- a/kattelmod/systems/mkat/sim_32ant.cfg
+++ b/kattelmod/systems/mkat/sim_32ant.cfg
@@ -58,19 +58,31 @@ config = {
                 "type": "sdp.cal"
             }, 
             "sdp_l0": {
+                "archive": true, 
                 "continuum_factor": 1, 
                 "src_streams": [
                     "i0_baseline_correlation_products"
                 ], 
-                "type": "sdp.l0"
+                "type": "sdp.vis"
             }, 
             "sdp_l0_continuum": {
+                "archive": false, 
                 "continuum_factor": 16, 
                 "src_streams": [
                     "i0_baseline_correlation_products"
                 ], 
-                "type": "sdp.l0"
+                "type": "sdp.vis"
+            }, 
+            "sdp_l1_flags": {
+                "archive": true, 
+                "calibration": [
+                    "cal"
+                ], 
+                "src_streams": [
+                    "sdp_l0"
+                ], 
+                "type": "sdp.flags"
             }
         }, 
-        "version": "1.1"
+        "version": "2.0"
     }

--- a/kattelmod/systems/mkat/sim_32ant_32k.cfg
+++ b/kattelmod/systems/mkat/sim_32ant_32k.cfg
@@ -58,19 +58,31 @@ config = {
                 "type": "sdp.cal"
             }, 
             "sdp_l0": {
+                "archive": true, 
                 "continuum_factor": 1, 
                 "src_streams": [
                     "i0_baseline_correlation_products"
                 ], 
-                "type": "sdp.l0"
+                "type": "sdp.vis"
             }, 
             "sdp_l0_continuum": {
+                "archive": false, 
                 "continuum_factor": 16, 
                 "src_streams": [
                     "i0_baseline_correlation_products"
                 ], 
-                "type": "sdp.l0"
+                "type": "sdp.vis"
+            }, 
+            "sdp_l1_flags": {
+                "archive": true, 
+                "calibration": [
+                    "cal"
+                ], 
+                "src_streams": [
+                    "sdp_l0"
+                ], 
+                "type": "sdp.flags"
             }
         }, 
-        "version": "1.1"
+        "version": "2.0"
     }

--- a/kattelmod/systems/mkat/sim_60ant.cfg
+++ b/kattelmod/systems/mkat/sim_60ant.cfg
@@ -58,19 +58,31 @@ config = {
                 "type": "sdp.cal"
             }, 
             "sdp_l0": {
+                "archive": true, 
                 "continuum_factor": 1, 
                 "src_streams": [
                     "i0_baseline_correlation_products"
                 ], 
-                "type": "sdp.l0"
+                "type": "sdp.vis"
             }, 
             "sdp_l0_continuum": {
+                "archive": false, 
                 "continuum_factor": 16, 
                 "src_streams": [
                     "i0_baseline_correlation_products"
                 ], 
-                "type": "sdp.l0"
+                "type": "sdp.vis"
+            }, 
+            "sdp_l1_flags": {
+                "archive": true, 
+                "calibration": [
+                    "cal"
+                ], 
+                "src_streams": [
+                    "sdp_l0"
+                ], 
+                "type": "sdp.flags"
             }
         }, 
-        "version": "1.1"
+        "version": "2.0"
     }


### PR DESCRIPTION
This updates the config dictionaries to the newer API version. The
semantics should be equivalent.

Depends on ska-sa/katsdpcontroller#255.