### PR TITLE
Allow integration time to be overridden in dictionary

### DIFF
--- a/kattelmod/systems/mkat/sdp.py
+++ b/kattelmod/systems/mkat/sdp.py
@@ -65,7 +65,7 @@ class ScienceDataProcessor(KATCPComponent):
                     simulate['antennas'] = [receptor.description for receptor in receptors]
         # Insert the dump rate
         for output in config['outputs'].values():
-            if output['type'] in ['sdp.l0', 'sdp.vis']:
+            if output['type'] in ['sdp.l0', 'sdp.vis'] and 'output_int_time' not in output:
                 output['output_int_time'] = 1.0 / sub.dump_rate
         msg = self._client.req.product_configure(subarray_product, json.dumps(config),
                                                  timeout=300)


### PR DESCRIPTION
This was useful for a test where I wanted to run several ingests with
different output integration times, where a single value in the config
doesn't cut it.