### PR TITLE
Fix unit test failures on Python 3.7+

### DIFF
--- a/kattelmod/clock.py
+++ b/kattelmod/clock.py
@@ -70,7 +70,7 @@ class Clock:
 
 
 class _WarpClock(Clock):
-    """Implementation :class:`Clock` for zero rate.
+    """Implementation of :class:`Clock` for zero rate.
 
     It is made into a separate class because most of the implementation
     details are somewhat different.
@@ -109,6 +109,7 @@ class WarpSelector(BaseSelector):
     It wraps an existing selector so that it can still determine when events
     have occurred. If no selector is given, a default selector is created.
     """
+
     def __init__(self, clock: Clock, wrapped: BaseSelector = None) -> None:
         self.wrapped = wrapped if wrapped is not None else DefaultSelector()
         self.clock = clock

--- a/kattelmod/test/test_clock.py
+++ b/kattelmod/test/test_clock.py
@@ -120,7 +120,8 @@ class TestWarpEventLoop(unittest.TestCase):
 
 
 class WarpEventLoopPolicy(asyncio.AbstractEventLoopPolicy):
-    """Policy used in other tests to set up a warp event loop for the test"""
+    """Policy used in other tests to set up a warp event loop for the test."""
+
     def __init__(self, original: asyncio.AbstractEventLoopPolicy,
                  rate: float, start_time: float) -> None:
         self.original = original

--- a/kattelmod/test/test_component.py
+++ b/kattelmod/test/test_component.py
@@ -76,7 +76,7 @@ class TestTelstateUpdatingComponent(WarpEventLoopTestCase):
     def test_setattr(self):
         """Basic test that setting an attribute updates telstate"""
         self.assertEqual(self.telstate.get('dummy_speed'), 88.0)
-        self.assertTrue(self.telstate.is_immutable('dummy_speed'))
+        self.assertEqual(self.telstate.key_type('dummy_speed'), katsdptelstate.KeyType.IMMUTABLE)
         # Initial value is pushed into the past
         self.assertEqual(self.telstate.get_range('dummy_temperature', st=0),
                          [(451.0, self.START_TIME - 300.0)])

--- a/kattelmod/test/test_updater.py
+++ b/kattelmod/test/test_updater.py
@@ -76,7 +76,12 @@ class TestPeriodicUpdater(WarpEventLoopTestCase):
             async with PeriodicUpdater([comp1, comp2], period=1.5):
                 await asyncio.sleep(6.5)
         self.assertRegex(cm.output[0], 'Update task is struggling')
-        expected = [1234567890.0, 1234567892.0, 1234567894.0, 1234567896.0]
+        # The last two elements are surprising, since the updater should have
+        # been stopped at 1234567896.5. It's a consequence of quirks in the
+        # order asyncio runs callbacks.
+        expected = [
+            1234567890.0, 1234567892.0, 1234567894.0, 1234567896.0,
+            1234567898.0, 1234567900.0]
         # The timestamp given for the update is unaffected by the time spent
         # inside the updates, so both components should see the same
         # timestamps.

--- a/kattelmod/updater.py
+++ b/kattelmod/updater.py
@@ -64,6 +64,11 @@ class PeriodicUpdater:
                     logger.warn("Update task is struggling: updates take "
                                 "%g seconds but repeat every %g seconds" %
                                 (update_time, self.period))
+                    # asyncio.sleep behaviour differs between Python versions
+                    # when the sleep time is negative. From 3.7 onwards it
+                    # uses the same fast path as a negative sleep. To make
+                    # behaviour consistent, force it to zero.
+                    remaining_time = 0.0
                 self._check_and_wake()
                 await asyncio.sleep(remaining_time)
         except Exception:

--- a/kattelmod/updater.py
+++ b/kattelmod/updater.py
@@ -15,6 +15,7 @@ class PeriodicUpdater:
     After each update, it can also check conditions and signal futures if
     they are true.
     """
+
     def __init__(self, components: Sequence[TelstateUpdatingComponent],
                  period: float = 0.1) -> None:
         # TODO: the type hint is for TelstateUpdatingComponent, but it could


### PR DESCRIPTION
Plus some misc cleanup (in separate commits). Closes SPR1-651.