### PR TITLE
Convert to use async telstate

### DIFF
--- a/kattelmod/systems/mkat/session.py
+++ b/kattelmod/systems/mkat/session.py
@@ -1,8 +1,10 @@
 import argparse
 from typing import Any
 
+import aioredis
 from katpoint import Timestamp
-from katsdptelstate import TelescopeState
+from katsdptelstate.aio import TelescopeState
+import katsdptelstate.aio.redis
 
 from kattelmod.session import CaptureSession as BaseCaptureSession, CaptureState
 
@@ -22,8 +24,15 @@ class CaptureSession(BaseCaptureSession):
             endpoint = await self.sdp.get_telstate()
         else:
             endpoint = ''
-        return None if not endpoint else TelescopeState(endpoint) \
-            if endpoint != 'fake' else TelescopeState()
+
+        if not endpoint:
+            return None
+        elif endpoint != 'fake':
+            client = await aioredis.create_redis_pool(f'redis://{endpoint}')
+            backend = katsdptelstate.aio.redis.RedisBackend(client)
+            return TelescopeState(backend)
+        else:
+            return TelescopeState()
 
     async def product_configure(self, args: argparse.Namespace) -> CaptureState:
         initial_state = CaptureState.UNKNOWN
@@ -44,7 +53,7 @@ class CaptureSession(BaseCaptureSession):
         if 'sdp' in self:
             await self.sdp.capture_init()
             try:
-                capture_block_id = self._telstate['sdp_capture_block_id']
+                capture_block_id = await self._telstate['sdp_capture_block_id']
             except KeyError:
                 self.logger.warning('No sdp_capture_block_id in telstate - '
                                     'assuming simulated environment')
@@ -69,5 +78,8 @@ class CaptureSession(BaseCaptureSession):
             await self.sdp.capture_done()
 
     async def product_deconfigure(self) -> None:
+        if self._telstate:
+            self._telstate.backend.close()
+            await self._telstate.backend.wait_closed()
         if 'sdp' in self:
             await self.sdp.product_deconfigure()

--- a/kattelmod/systems/mkat/session.py
+++ b/kattelmod/systems/mkat/session.py
@@ -27,12 +27,12 @@ class CaptureSession(BaseCaptureSession):
 
         if not endpoint:
             return None
-        elif endpoint != 'fake':
+        elif endpoint == 'fake':
+            return TelescopeState()
+        else:
             client = await aioredis.create_redis_pool(f'redis://{endpoint}')
             backend = katsdptelstate.aio.redis.RedisBackend(client)
             return TelescopeState(backend)
-        else:
-            return TelescopeState()
 
     async def product_configure(self, args: argparse.Namespace) -> CaptureState:
         initial_state = CaptureState.UNKNOWN

--- a/kattelmod/test/test_updater.py
+++ b/kattelmod/test/test_updater.py
@@ -76,12 +76,7 @@ class TestPeriodicUpdater(WarpEventLoopTestCase):
             async with PeriodicUpdater([comp1, comp2], period=1.5):
                 await asyncio.sleep(6.5)
         self.assertRegex(cm.output[0], 'Update task is struggling')
-        # The last two elements are surprising, since the updater should have
-        # been stopped at 1234567896.5. It's a consequence of quirks in the
-        # order asyncio runs callbacks.
-        expected = [
-            1234567890.0, 1234567892.0, 1234567894.0, 1234567896.0,
-            1234567898.0, 1234567900.0]
+        expected = [1234567890.0, 1234567892.0, 1234567894.0, 1234567896.0]
         # The timestamp given for the update is unaffected by the time spent
         # inside the updates, so both components should see the same
         # timestamps.

--- a/kattelmod/updater.py
+++ b/kattelmod/updater.py
@@ -19,7 +19,7 @@ class PeriodicUpdater:
     def __init__(self, components: Sequence[TelstateUpdatingComponent],
                  period: float = 0.1) -> None:
         # TODO: the type hint is for TelstateUpdatingComponent, but it could
-        # be replaced by a mypy Protocol requiring _update.
+        # be replaced by a mypy Protocol requiring _update and _flush.
         self.components = components
         self.period = period
         self._task = None        # type: Optional[asyncio.Task]
@@ -57,6 +57,8 @@ class PeriodicUpdater:
                     component._update_time = timestamp
                     component._update(timestamp)
                     component._update_time = 0.0
+                for component in self.components:
+                    await component._flush()
                 after_update = clock.time()
                 update_time = after_update - timestamp
                 remaining_time = self.period - update_time

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 aiokatcp
-aioredis                  # via katsdptelstate[aio]
+aioredis==1.3.1           # via katsdptelstate[aio]
 async-timeout
 decorator                 # via aiokatcp
 ephem                     # via pyephem

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 aiokatcp
-aioredis==1.3.1           # via katsdptelstate[aio]
+aioredis                  # via katsdptelstate[aio]
 async-timeout
 decorator                 # via aiokatcp
 ephem                     # via pyephem

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,10 @@
 aiokatcp
+aioredis                  # via katsdptelstate[aio]
 async-timeout
 decorator                 # via aiokatcp
 ephem                     # via pyephem
 future                    # via katpoint
+hiredis                   # via aioredis
 msgpack                   # via katsdptelstate
 netifaces                 # via katsdptelstate
 numpy

--- a/setup.py
+++ b/setup.py
@@ -24,5 +24,6 @@ setup(name="kattelmod",
       test_suite="nose.collector",
       setup_requires=['katversion'],
       use_katversion=True,
+      python_requires='>=3.6',     # Required by katsdptelstate[aio]
       tests_require=["nose", "asynctest"],
-      install_requires=["numpy", "aiokatcp", "async-timeout", "katpoint", "katsdptelstate"])
+      install_requires=["numpy", "aiokatcp", "async-timeout", "katpoint", "katsdptelstate[aio]"])


### PR DESCRIPTION
This avoids blocking the event loop. More usefully, it should improve
performance on high-latency links, because multiple updates can occur in
parallel using the aioredis connection pool.