### PR TITLE
Fix breakage caused by async_timeout upgrade

### DIFF
--- a/kattelmod/clock.py
+++ b/kattelmod/clock.py
@@ -186,4 +186,4 @@ def real_timeout(timeout: Optional[float], *,
             timeout /= loop.clock.rate
         except (AttributeError, ZeroDivisionError):
             pass
-    return async_timeout.timeout(timeout, loop=loop)
+    return async_timeout.timeout(timeout)

--- a/kattelmod/clock.py
+++ b/kattelmod/clock.py
@@ -172,16 +172,16 @@ def get_clock() -> Clock:
     return loop.clock
 
 
-def real_timeout(timeout: Optional[float], *,
-                 loop: Optional[asyncio.AbstractEventLoop] = None) -> async_timeout.timeout:
+# The return type is quoted so that it won't break at runtime with
+# async-timeout versions prior to 4.0 which introduced the class.
+def real_timeout(timeout: Optional[float]) -> "async_timeout.Timeout":
     """Wrapper for async_timeout that tries to count in real time.
 
     If the event loop has a rate of 0 (dry-run) it doesn't do anything special,
     but otherwise it scales the timeout appropriately.
     """
     if timeout is not None:
-        if loop is None:
-            loop = asyncio.get_event_loop()
+        loop = asyncio.get_event_loop()
         try:
             timeout /= loop.clock.rate
         except (AttributeError, ZeroDivisionError):

--- a/kattelmod/component.py
+++ b/kattelmod/component.py
@@ -175,7 +175,7 @@ class KATCPComponent(Component):
             return
         await super()._start()
         try:
-            with real_timeout(5):
+            async with real_timeout(5):
                 self._client = await aiokatcp.Client.connect(self._endpoint.host, self._endpoint.port)
         except asyncio.TimeoutError:
             raise asyncio.TimeoutError("Timed out trying to connect '{}' to client '{}'"

--- a/kattelmod/systems/mkat/sdp.py
+++ b/kattelmod/systems/mkat/sdp.py
@@ -74,7 +74,7 @@ class ScienceDataProcessor(KATCPComponent):
             if output['type'] == 'sdp.vis' and 'output_int_time' not in output:
                 output['output_int_time'] = 1.0 / sub.dump_rate
         try:
-            with real_timeout(300):
+            async with real_timeout(300):
                 msg, _ = await self._client.request(
                     'product-configure', subarray_product, json.dumps(config))
         except aiokatcp.FailReply as exc:
@@ -84,7 +84,7 @@ class ScienceDataProcessor(KATCPComponent):
 
     async def product_deconfigure(self) -> None:
         self._validate()
-        with real_timeout(300):
+        async with real_timeout(300):
             await self._client.request('product-deconfigure', self.subarray_product)
 
     async def get_telstate(self) -> str:
@@ -98,10 +98,10 @@ class ScienceDataProcessor(KATCPComponent):
 
     async def capture_init(self) -> None:
         self._validate()
-        with real_timeout(10):
+        async with real_timeout(10):
             await self._client.request('capture-init', self.subarray_product)
 
     async def capture_done(self) -> None:
         self._validate()
-        with real_timeout(300):
+        async with real_timeout(300):
             await self._client.request('capture-done', self.subarray_product)


### PR DESCRIPTION
The latest version of async_timeout no longer accepts a `loop` argument
(it uses the currently-running loop).
